### PR TITLE
Upgrade Nuclei from V2 to V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ API : [Developer API](https://developer.shodan.io/api)
 ```
 ### 6. Install nuclei [@projectdiscovery](https://github.com/projectdiscovery/nuclei)
 ```bash
-# go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest
+# go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
 ```
 ### 7. Install lolcat
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ declare -A tools='(
 ["jq"]="sudo apt install jq -y -qq"
 ["httprobe"]="go install github.com/tomnomnom/httprobe@master"
 ["interlace"]="sudo git clone https://github.com/codingo/Interlace.git"
-["nuclei"]="go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest"
+["nuclei"]="go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest"
 ["lolcat"]="sudo apt install lolcat -y -qq"
 ["anew"]="go install github.com/tomnomnom/anew@master"
 )'

--- a/karma_v2
+++ b/karma_v2
@@ -446,7 +446,7 @@ check_requirements(){
 	fi
 	type -P "${nuclei_bin}" &>/dev/null
 	if [[ ! $? -eq 0 ]]; then
-		printf "\n[${red}!${end}] ${yellow}Error: Unable to find ${nuclei_bin}. Make sure it installed OR \n\t - GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei${end}\n";exit 1
+		printf "\n[${red}!${end}] ${yellow}Error: Unable to find ${nuclei_bin}. Make sure it installed OR \n\t - GO111MODULE=on go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest${end}\n";exit 1
 	fi
 	type -P "${python3_bin}" &>/dev/null
 	if [[ ! $? -eq 0 ]]; then


### PR DESCRIPTION
Upgrade the nuclei dependency from nuclei v2 to nuclei v3 (effectively v2.9.15 => v3.3.4)

Confirmed the input parameters and output results are the same between the two versions as used within karma.

```
favicons_detection(){
	rm -f ${BASE_DIR}/favicon-detect.yaml 2> /dev/null
	wget -q https://raw.githubusercontent.com/projectdiscovery/nuclei-templates/main/http/technologies/favicon-detect.yaml -O ${BASE_DIR}/favicon-detect.yaml > /dev/null
    sed -i 's/\- \"{{BaseURL}}\/favicon.ico"/- "{{BaseURL}}\"/g' ${BASE_DIR}/favicon-detect.yaml
	printf "${upper}\n  ${greenbg}Favicons Hash Detection${end} [  Technology Detection via Nuclei custom template ] \n${lower}${end}\n"
	o=$(cat "${BASE_DIR}/output/$folder/favicons_${target}.txt" | ${nuclei_bin} -t ${nuclei_template} -bs 100 -c 100 -silent|awk '{print $NF " : " $3}'|sed 's/ /,|,/g' | column -s ',' -t);if [ -z "$o" ];then printf "\n[${red}!${end}] ${yellow}No results found [ By increasing shodan download limit=-1 may help !]\n"${end};else printf "$o \n";fi;printf "\n"
 }
```